### PR TITLE
[#1] 애견미용 도메인 엔티티 전체 추가

### DIFF
--- a/src/main/java/com/dangdang/check/DangdangCheckApplication.java
+++ b/src/main/java/com/dangdang/check/DangdangCheckApplication.java
@@ -2,7 +2,9 @@ package com.dangdang.check;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class DangdangCheckApplication {
 

--- a/src/main/java/com/dangdang/check/domain/BaseEntity.java
+++ b/src/main/java/com/dangdang/check/domain/BaseEntity.java
@@ -1,0 +1,24 @@
+package com.dangdang.check.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/dangdang/check/domain/customer/Customer.java
+++ b/src/main/java/com/dangdang/check/domain/customer/Customer.java
@@ -1,0 +1,26 @@
+package com.dangdang.check.domain.customer;
+
+import com.dangdang.check.domain.BaseEntity;
+import com.dangdang.check.domain.store.Store;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "customers")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Customer extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    @Lob
+    private String specialNotes;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false)
+    private Store store;
+}

--- a/src/main/java/com/dangdang/check/domain/customer/CustomerPhone.java
+++ b/src/main/java/com/dangdang/check/domain/customer/CustomerPhone.java
@@ -1,0 +1,26 @@
+package com.dangdang.check.domain.customer;
+
+import com.dangdang.check.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "customer_phones")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CustomerPhone extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String label; // 전화번호 별칭(예: "엄마", "아빠")
+    private String phoneNumber;
+    @Enumerated(EnumType.STRING)
+    private PhoneType phoneType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "customer_id")
+    private Customer customer;
+}

--- a/src/main/java/com/dangdang/check/domain/customer/PhoneType.java
+++ b/src/main/java/com/dangdang/check/domain/customer/PhoneType.java
@@ -1,0 +1,5 @@
+package com.dangdang.check.domain.customer;
+
+public enum PhoneType {
+    MOBILE, HOME, OTHER
+}

--- a/src/main/java/com/dangdang/check/domain/employee/Employee.java
+++ b/src/main/java/com/dangdang/check/domain/employee/Employee.java
@@ -1,0 +1,27 @@
+package com.dangdang.check.domain.employee;
+
+
+import com.dangdang.check.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "employees")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Employee extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    private String nickname;
+    private String email;
+    private String loginId;
+    private String password;
+    private String mobilePhone;
+    @Enumerated(EnumType.STRING)
+    private Role role;
+}

--- a/src/main/java/com/dangdang/check/domain/employee/Employee.java
+++ b/src/main/java/com/dangdang/check/domain/employee/Employee.java
@@ -2,6 +2,7 @@ package com.dangdang.check.domain.employee;
 
 
 import com.dangdang.check.domain.BaseEntity;
+import com.dangdang.check.domain.store.Store;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -24,4 +25,8 @@ public class Employee extends BaseEntity {
     private String mobilePhone;
     @Enumerated(EnumType.STRING)
     private Role role;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id")
+    private Store store;
 }

--- a/src/main/java/com/dangdang/check/domain/employee/Role.java
+++ b/src/main/java/com/dangdang/check/domain/employee/Role.java
@@ -1,0 +1,9 @@
+package com.dangdang.check.domain.employee;
+
+public enum Role {
+    GROOMER,     // 미용사 (일반 선생님)
+    HEAD_GROOMER, // 실장
+    OWNER,        // 원장
+    ADMIN,       // 관리자
+    DEFAULT      // 일반 사용자
+}

--- a/src/main/java/com/dangdang/check/domain/grooming/GroomingRecord.java
+++ b/src/main/java/com/dangdang/check/domain/grooming/GroomingRecord.java
@@ -1,0 +1,40 @@
+package com.dangdang.check.domain.grooming;
+
+import com.dangdang.check.domain.BaseEntity;
+import com.dangdang.check.domain.employee.Employee;
+import com.dangdang.check.domain.pet.Pet;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "grooming_records")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GroomingRecord extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    String styleTag; // 예: '전체 3mm 테디베어컷'
+    @Lob
+    String specialNotes; // 미용 특이사항 및 상세기록
+    LocalDateTime groomedAt; // 미용한 시간
+    private Double weight;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pet_id", nullable = false)
+    Pet pet;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "employee_id", nullable = false)
+    Employee employee; // 미용 담당 직원
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "grooming_reservation_id")
+    private GroomingReservation groomingReservation; // 미용 예약 정보
+
+}

--- a/src/main/java/com/dangdang/check/domain/grooming/GroomingRecordImage.java
+++ b/src/main/java/com/dangdang/check/domain/grooming/GroomingRecordImage.java
@@ -1,0 +1,25 @@
+package com.dangdang.check.domain.grooming;
+
+import com.dangdang.check.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "grooming_record_images")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GroomingRecordImage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String originalFileName; // 원본 파일 이름
+    private String storedFileName; // 저장된 파일 이름
+    private String url; // 이미지 URL
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "grooming_record_id", nullable = false)
+    private GroomingRecord groomingRecord;
+}

--- a/src/main/java/com/dangdang/check/domain/grooming/GroomingReservation.java
+++ b/src/main/java/com/dangdang/check/domain/grooming/GroomingReservation.java
@@ -1,0 +1,33 @@
+package com.dangdang.check.domain.grooming;
+
+import com.dangdang.check.domain.BaseEntity;
+import com.dangdang.check.domain.customer.Customer;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "grooming_reservations")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GroomingReservation extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private LocalDateTime startAt;
+    private LocalDateTime endAt;
+    private String title;
+    @Lob
+    private String groomingRequest;
+    @Enumerated(EnumType.STRING)
+    private ReservationStatus reservationStatus;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "customer_id", nullable = false)
+    private Customer customer;
+
+}

--- a/src/main/java/com/dangdang/check/domain/grooming/GroomingReservationPet.java
+++ b/src/main/java/com/dangdang/check/domain/grooming/GroomingReservationPet.java
@@ -1,0 +1,27 @@
+package com.dangdang.check.domain.grooming;
+
+import com.dangdang.check.domain.BaseEntity;
+import com.dangdang.check.domain.pet.Pet;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "grooming_reservation_pets")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GroomingReservationPet extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "grooming_reservation_id", nullable = false)
+    private GroomingReservation groomingReservation;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pet_id", nullable = false)
+    private Pet pet;
+}

--- a/src/main/java/com/dangdang/check/domain/grooming/ReservationStatus.java
+++ b/src/main/java/com/dangdang/check/domain/grooming/ReservationStatus.java
@@ -1,0 +1,7 @@
+package com.dangdang.check.domain.grooming;
+
+public enum ReservationStatus {
+    RESERVED,   // 예약됨
+    NO_SHOW,    // 노쇼
+    CANCELED    // 취소됨
+}

--- a/src/main/java/com/dangdang/check/domain/payment/ItemType.java
+++ b/src/main/java/com/dangdang/check/domain/payment/ItemType.java
@@ -1,0 +1,5 @@
+package com.dangdang.check.domain.payment;
+
+public enum ItemType {
+    GROOMING, PRODUCT, PREPAID_TICKET, OTHER
+}

--- a/src/main/java/com/dangdang/check/domain/payment/Payment.java
+++ b/src/main/java/com/dangdang/check/domain/payment/Payment.java
@@ -1,0 +1,26 @@
+package com.dangdang.check.domain.payment;
+
+import com.dangdang.check.domain.BaseEntity;
+import com.dangdang.check.domain.customer.Customer;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@Entity
+@Table(name = "payments")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Payment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private BigDecimal totalAmount;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "customer_id", nullable = false)
+    private Customer customer;
+}

--- a/src/main/java/com/dangdang/check/domain/payment/PaymentItem.java
+++ b/src/main/java/com/dangdang/check/domain/payment/PaymentItem.java
@@ -1,0 +1,29 @@
+package com.dangdang.check.domain.payment;
+
+import com.dangdang.check.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@Entity
+@Table(name = "payment_items")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PaymentItem extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Enumerated(EnumType.STRING)
+    private ItemType itemType;
+    private Long itemId;
+    private Integer quantity;
+    private BigDecimal amount;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "payment_id", nullable = false)
+    private Payment payment;
+}

--- a/src/main/java/com/dangdang/check/domain/payment/PaymentMethod.java
+++ b/src/main/java/com/dangdang/check/domain/payment/PaymentMethod.java
@@ -1,0 +1,27 @@
+package com.dangdang.check.domain.payment;
+
+import com.dangdang.check.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@Entity
+@Table(name = "payment_methods")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PaymentMethod extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Enumerated(EnumType.STRING)
+    private PaymentMethodType paymentMethodType;
+    private BigDecimal amount;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "payment_id", nullable = false)
+    private Payment payment;
+}

--- a/src/main/java/com/dangdang/check/domain/payment/PaymentMethodType.java
+++ b/src/main/java/com/dangdang/check/domain/payment/PaymentMethodType.java
@@ -1,0 +1,5 @@
+package com.dangdang.check.domain.payment;
+
+public enum PaymentMethodType {
+    CASH, CARD, PREPAID_TICKET, BANK_TRANSFER
+}

--- a/src/main/java/com/dangdang/check/domain/pet/Gender.java
+++ b/src/main/java/com/dangdang/check/domain/pet/Gender.java
@@ -1,0 +1,5 @@
+package com.dangdang.check.domain.pet;
+
+public enum Gender {
+    MALE, FEMALE
+}

--- a/src/main/java/com/dangdang/check/domain/pet/GroomingRequestImage.java
+++ b/src/main/java/com/dangdang/check/domain/pet/GroomingRequestImage.java
@@ -1,0 +1,25 @@
+package com.dangdang.check.domain.pet;
+
+import com.dangdang.check.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "grooming_request_images")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GroomingRequestImage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String originalFileName; // 원본 파일 이름
+    private String storedFileName; // 저장된 파일 이름
+    private String url; // 이미지 URL
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pet_id", nullable = false)
+    private Pet pet;
+}

--- a/src/main/java/com/dangdang/check/domain/pet/Pet.java
+++ b/src/main/java/com/dangdang/check/domain/pet/Pet.java
@@ -1,0 +1,35 @@
+package com.dangdang.check.domain.pet;
+
+import com.dangdang.check.domain.BaseEntity;
+import com.dangdang.check.domain.customer.Customer;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@Entity
+@Table(name = "pets")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Pet extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+    private boolean neutered; // 중성화 여부
+    private boolean vaccinated; // 예방접종 여부
+    private Double weight;
+    private LocalDate birthday; // 생년월일
+    private String specialNotes; // 특이사항
+    private String species; // 예: "개", "고양이"
+    private String breedName; // 품종 이름
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "customer_id")
+    private Customer customer;
+}

--- a/src/main/java/com/dangdang/check/domain/prepaidticket/PrepaidTicket.java
+++ b/src/main/java/com/dangdang/check/domain/prepaidticket/PrepaidTicket.java
@@ -1,0 +1,26 @@
+package com.dangdang.check.domain.prepaidticket;
+
+import com.dangdang.check.domain.BaseEntity;
+import com.dangdang.check.domain.customer.Customer;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@Entity
+@Table(name = "prepaid_tickets")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PrepaidTicket extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private BigDecimal balance;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "customer_id", nullable = false)
+    private Customer customer;
+}

--- a/src/main/java/com/dangdang/check/domain/prepaidticket/PrepaidTicketHistory.java
+++ b/src/main/java/com/dangdang/check/domain/prepaidticket/PrepaidTicketHistory.java
@@ -1,0 +1,28 @@
+package com.dangdang.check.domain.prepaidticket;
+
+import com.dangdang.check.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@Entity
+@Table(name = "prepaid_ticket_histories")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PrepaidTicketHistory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private BigDecimal changeAmount;
+    @Enumerated(EnumType.STRING)
+    private TransactionType transactionType;
+    private String description;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "prepaid_ticket_id", nullable = false)
+    private PrepaidTicket prepaidTicket;
+}

--- a/src/main/java/com/dangdang/check/domain/prepaidticket/TransactionType.java
+++ b/src/main/java/com/dangdang/check/domain/prepaidticket/TransactionType.java
@@ -1,0 +1,5 @@
+package com.dangdang.check.domain.prepaidticket;
+
+public enum TransactionType {
+    CHARGE, USE
+}

--- a/src/main/java/com/dangdang/check/domain/product/Product.java
+++ b/src/main/java/com/dangdang/check/domain/product/Product.java
@@ -1,0 +1,27 @@
+package com.dangdang.check.domain.product;
+
+import com.dangdang.check.domain.BaseEntity;
+import com.dangdang.check.domain.store.Store;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@Entity
+@Table(name = "products")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Product extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    private BigDecimal price;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false)
+    private Store store;
+}

--- a/src/main/java/com/dangdang/check/domain/product/ProductHistory.java
+++ b/src/main/java/com/dangdang/check/domain/product/ProductHistory.java
@@ -1,0 +1,26 @@
+package com.dangdang.check.domain.product;
+
+import com.dangdang.check.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@Entity
+@Table(name = "product_histories")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductHistory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    private BigDecimal price;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+}

--- a/src/main/java/com/dangdang/check/domain/store/Address.java
+++ b/src/main/java/com/dangdang/check/domain/store/Address.java
@@ -1,0 +1,17 @@
+package com.dangdang.check.domain.store;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Address {
+    private String zipCode; // 우편번호
+    private String state; // 시/도
+    private String city; // 시/군/구
+    private String street; // 도로명 또는 지번 주소
+    private String detail; // 상세 주소 (건물명, 동/호수 등)
+}

--- a/src/main/java/com/dangdang/check/domain/store/BusinessInfo.java
+++ b/src/main/java/com/dangdang/check/domain/store/BusinessInfo.java
@@ -8,20 +8,20 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "stores")
+@Table(name = "business_infos")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Store extends BaseEntity {
+public class BusinessInfo extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private String name;
-    private String email;
-    private String mainPhone;
+    private String businessName;
+    private String businessRegistrationNumber;
+    private String businessType;
+    private String representativeName;
     @Embedded
     private Address address;
-
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "business_info_id")
-    private BusinessInfo businessInfo;
+    @Enumerated(EnumType.STRING)
+    private RegistrationStatus registrationStatus;
+    private String rejectedReason;
 }

--- a/src/main/java/com/dangdang/check/domain/store/RegistrationStatus.java
+++ b/src/main/java/com/dangdang/check/domain/store/RegistrationStatus.java
@@ -1,0 +1,5 @@
+package com.dangdang.check.domain.store;
+
+public enum RegistrationStatus {
+    PENDING, APPROVED, REJECTED
+}

--- a/src/main/java/com/dangdang/check/domain/store/Store.java
+++ b/src/main/java/com/dangdang/check/domain/store/Store.java
@@ -1,0 +1,23 @@
+package com.dangdang.check.domain.store;
+
+import com.dangdang.check.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "stores")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Store extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    private String email;
+    private String mainPhone;
+    @Embedded
+    private Address address;
+}

--- a/src/main/java/com/dangdang/check/domain/store/StoreInvitation.java
+++ b/src/main/java/com/dangdang/check/domain/store/StoreInvitation.java
@@ -1,0 +1,36 @@
+package com.dangdang.check.domain.store;
+
+import com.dangdang.check.domain.employee.Employee;
+import com.dangdang.check.domain.employee.Role;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "store_invitations")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StoreInvitation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String email;
+    private Role invitedRole;
+    private String invitationToken;
+    private LocalDateTime sentAt;
+    private LocalDateTime expiresAt;
+    private LocalDateTime respondedAt;
+    private Boolean accepted;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false)
+    private Store store;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "inviter_id", nullable = false)
+    private Employee employee;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=dangdang-check

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,15 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/dangdang_check?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: root
+    password: 1234
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL8Dialect
+        format_sql: true


### PR DESCRIPTION
- 고객, 고객 전화번호, 반려동물, 미용 요청 이미지, 직원, 예약, 미용 기록, 결제, 선불권, 물품, 가게 및 초대 등 엔티티 정의
- 엔티티 간 관계 및 제약조건 설정(단방향만 설정, 필요시 양방향으로 설정 예정)
- 추후 서비스 로직 개발 예정