### PR TITLE
[#21] 리프레시 토큰 발급 및 Store 수정

### DIFF
--- a/src/main/java/com/dangdang/check/common/config/SecurityConfig.java
+++ b/src/main/java/com/dangdang/check/common/config/SecurityConfig.java
@@ -53,7 +53,7 @@ public class SecurityConfig implements WebMvcConfigurer {
                         .requestMatchers("/", "/login", "/api/reissue")
                         .permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/employees").permitAll()
-                        .requestMatchers(HttpMethod.POST, "/api/logout").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/api/logout", "api/store-requests").authenticated()
                 )
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/src/main/java/com/dangdang/check/common/config/SecurityConfig.java
+++ b/src/main/java/com/dangdang/check/common/config/SecurityConfig.java
@@ -50,7 +50,7 @@ public class SecurityConfig implements WebMvcConfigurer {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(request -> request
-                        .requestMatchers("/", "/login")
+                        .requestMatchers("/", "/login", "/api/reissue")
                         .permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/employees").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/logout").authenticated()

--- a/src/main/java/com/dangdang/check/common/filter/LoginFilter.java
+++ b/src/main/java/com/dangdang/check/common/filter/LoginFilter.java
@@ -68,6 +68,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         Cookie cookie = new Cookie(key, value);
         cookie.setMaxAge((int) AuthConstants.REFRESH_TOKEN_TTL_MS);
         cookie.setHttpOnly(true);
+        cookie.setSecure(true);
         return cookie;
     }
 

--- a/src/main/java/com/dangdang/check/core/store/BusinessInfoCommandService.java
+++ b/src/main/java/com/dangdang/check/core/store/BusinessInfoCommandService.java
@@ -1,0 +1,18 @@
+package com.dangdang.check.core.store;
+
+import com.dangdang.check.domain.store.BusinessInfoEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BusinessInfoCommandService {
+
+    private final BusinessInfoJpaRepository businessInfoJpaRepository;
+
+    @Transactional
+    public BusinessInfoEntity save(BusinessInfoEntity businessInfoEntity) {
+        return businessInfoJpaRepository.save(businessInfoEntity);
+    }
+}

--- a/src/main/java/com/dangdang/check/core/store/BusinessInfoJpaRepository.java
+++ b/src/main/java/com/dangdang/check/core/store/BusinessInfoJpaRepository.java
@@ -1,0 +1,7 @@
+package com.dangdang.check.core.store;
+
+import com.dangdang.check.domain.store.BusinessInfoEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BusinessInfoJpaRepository extends JpaRepository<BusinessInfoEntity, Long> {
+}

--- a/src/main/java/com/dangdang/check/core/token/JwtService.java
+++ b/src/main/java/com/dangdang/check/core/token/JwtService.java
@@ -16,14 +16,14 @@ public class JwtService {
     private final JwtUtil jwtUtil;
 
     public void validateToken(String token, String category) {
+        if (!category.equals(jwtUtil.getCategory(token))) {
+            throw new JwtValidationException("invalid token");
+        }
+
         try {
             jwtUtil.isExpired(token);
         } catch (ExpiredJwtException e) {
             throw new JwtValidationException("token expired", e);
-        }
-
-        if (!category.equals(jwtUtil.getCategory(token))) {
-            throw new JwtValidationException("invalid token");
         }
     }
 
@@ -32,6 +32,14 @@ public class JwtService {
         String loginId = jwtUtil.getLoginId(token);
         String role = jwtUtil.getRole(token);
         return new EmployeeDetails(loginId, null, Role.valueOf(role));
+    }
+
+    public String getLoginId(String token) {
+        return jwtUtil.getLoginId(token);
+    }
+
+    public String getRole(String token) {
+        return jwtUtil.getRole(token);
     }
 
 

--- a/src/main/java/com/dangdang/check/core/token/RefreshTokenFindService.java
+++ b/src/main/java/com/dangdang/check/core/token/RefreshTokenFindService.java
@@ -1,0 +1,15 @@
+package com.dangdang.check.core.token;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenFindService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public boolean existsById(String id) {
+        return refreshTokenRepository.existsById(id);
+    }
+}

--- a/src/main/java/com/dangdang/check/domain/employee/EmployeeEntity.java
+++ b/src/main/java/com/dangdang/check/domain/employee/EmployeeEntity.java
@@ -59,6 +59,10 @@ public class EmployeeEntity extends BaseEntity {
         this.store = store;
     }
 
+    public boolean hasStore() {
+        return this.store != null;
+    }
+
     public void modifyProfile(String name, String nickname) {
         modifyName(name);
         modifyNickName(nickname);

--- a/src/main/java/com/dangdang/check/domain/identity/ReissueApiService.java
+++ b/src/main/java/com/dangdang/check/domain/identity/ReissueApiService.java
@@ -1,0 +1,8 @@
+package com.dangdang.check.domain.identity;
+
+import com.dangdang.check.domain.identity.response.ReissueTokenInfo;
+
+public interface ReissueApiService {
+
+    ReissueTokenInfo reissueToken(String refreshToken);
+}

--- a/src/main/java/com/dangdang/check/domain/identity/ReissueApiServiceImpl.java
+++ b/src/main/java/com/dangdang/check/domain/identity/ReissueApiServiceImpl.java
@@ -1,0 +1,44 @@
+package com.dangdang.check.domain.identity;
+
+import com.dangdang.check.common.constant.AuthConstants;
+import com.dangdang.check.core.token.JwtService;
+import com.dangdang.check.core.token.RefreshTokenCommandService;
+import com.dangdang.check.core.token.RefreshTokenFindService;
+import com.dangdang.check.domain.identity.response.ReissueTokenInfo;
+import com.dangdang.check.domain.token.RefreshTokenEntityFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+
+@Service
+@RequiredArgsConstructor
+public class ReissueApiServiceImpl implements ReissueApiService {
+
+    private final JwtService jwtService;
+    private final RefreshTokenCommandService refreshTokenCommandService;
+    private final RefreshTokenFindService refreshTokenFindService;
+
+    @Override
+    public ReissueTokenInfo reissueToken(String refreshToken) {
+        validateRefreshToken(refreshToken);
+
+        String loginId = jwtService.getLoginId(refreshToken);
+        String role = jwtService.getRole(refreshToken);
+
+        String newAccessToken = jwtService.createAccessToken(loginId, role);
+        String newRefreshToken = jwtService.createRefreshToken(loginId, role);
+
+        refreshTokenCommandService.deleteById(refreshToken);
+        refreshTokenCommandService.save(RefreshTokenEntityFactory.of(newRefreshToken, loginId));
+
+        return new ReissueTokenInfo(newAccessToken, newRefreshToken);
+    }
+
+    private void validateRefreshToken(String refreshToken) {
+        Assert.hasText(refreshToken, "Refresh token is required");
+        jwtService.validateToken(refreshToken, AuthConstants.REFRESH_TOKEN_TYPE);
+        if (!refreshTokenFindService.existsById(refreshToken)) {
+            throw new RuntimeException("Refresh token does not exist");
+        }
+    }
+}

--- a/src/main/java/com/dangdang/check/domain/identity/response/ReissueTokenInfo.java
+++ b/src/main/java/com/dangdang/check/domain/identity/response/ReissueTokenInfo.java
@@ -1,0 +1,15 @@
+package com.dangdang.check.domain.identity.response;
+
+import lombok.Getter;
+
+@Getter
+public class ReissueTokenInfo {
+
+    private final String accessToken;
+    private final String refreshToken;
+
+    public ReissueTokenInfo(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/dangdang/check/domain/store/StoreEntity.java
+++ b/src/main/java/com/dangdang/check/domain/store/StoreEntity.java
@@ -28,8 +28,8 @@ public class StoreEntity extends BaseEntity {
     private boolean isDeleted = false;
     private LocalDateTime deletedAt;
 
-    @JoinColumn(name = "business_info_id")
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "business_info_id", nullable = false)
     private BusinessInfoEntity businessInfo;
 
     @Builder

--- a/src/main/java/com/dangdang/check/domain/store/StoreServiceImpl.java
+++ b/src/main/java/com/dangdang/check/domain/store/StoreServiceImpl.java
@@ -27,6 +27,11 @@ public class StoreServiceImpl implements StoreService {
     @Transactional
     public StoreInfo registerStore(RegisterStore command) {
         EmployeeEntity employee = employeeFindService.findByLoginId(command.getLoginId());
+
+        if (employee.hasStore()) {
+            throw new RuntimeException("이미 매장을 등록한 직원입니다.");
+        }
+
         BusinessInfoEntity businessInfo = businessInfoCommandService.save(BusinessInfoEntityFactory.from(command));
         StoreEntity store = storeCommandService.save(StoreEntityFactory.from(command, businessInfo));
         employee.addStore(store);

--- a/src/main/java/com/dangdang/check/domain/store/StoreServiceImpl.java
+++ b/src/main/java/com/dangdang/check/domain/store/StoreServiceImpl.java
@@ -1,6 +1,7 @@
 package com.dangdang.check.domain.store;
 
 import com.dangdang.check.core.employee.EmployeeFindService;
+import com.dangdang.check.core.store.BusinessInfoCommandService;
 import com.dangdang.check.core.store.StoreCommandService;
 import com.dangdang.check.core.store.StoreFindService;
 import com.dangdang.check.domain.employee.EmployeeEntity;
@@ -20,12 +21,14 @@ public class StoreServiceImpl implements StoreService {
     private final StoreFindService storeFindService;
     private final EmployeeFindService employeeFindService;
     private final StoreCommandService storeCommandService;
+    private final BusinessInfoCommandService businessInfoCommandService;
 
     @Override
     @Transactional
     public StoreInfo registerStore(RegisterStore command) {
         EmployeeEntity employee = employeeFindService.findByLoginId(command.getLoginId());
-        StoreEntity store = storeCommandService.save(StoreEntityFactory.from(command, BusinessInfoEntityFactory.from(command)));
+        BusinessInfoEntity businessInfo = businessInfoCommandService.save(BusinessInfoEntityFactory.from(command));
+        StoreEntity store = storeCommandService.save(StoreEntityFactory.from(command, businessInfo));
         employee.addStore(store);
         return StoreEntityFactory.to(store);
     }

--- a/src/main/java/com/dangdang/check/interfaces/identity/ReissueApiController.java
+++ b/src/main/java/com/dangdang/check/interfaces/identity/ReissueApiController.java
@@ -28,6 +28,7 @@ public class ReissueApiController {
         Cookie cookie = new Cookie(key, value);
         cookie.setMaxAge((int) AuthConstants.REFRESH_TOKEN_TTL_MS);
         cookie.setHttpOnly(true);
+        cookie.setSecure(true);
         return cookie;
     }
 }

--- a/src/main/java/com/dangdang/check/interfaces/identity/ReissueApiController.java
+++ b/src/main/java/com/dangdang/check/interfaces/identity/ReissueApiController.java
@@ -1,0 +1,33 @@
+package com.dangdang.check.interfaces.identity;
+
+import com.dangdang.check.common.constant.AuthConstants;
+import com.dangdang.check.domain.identity.ReissueApiService;
+import com.dangdang.check.domain.identity.response.ReissueTokenInfo;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ReissueApiController {
+
+    private final ReissueApiService reissueApiService;
+
+    @PostMapping("/api/reissue")
+    public void reissue(@CookieValue(value = AuthConstants.REFRESH_TOKEN_TYPE, required = false) String refreshToken,
+                        HttpServletResponse response) {
+        ReissueTokenInfo reissueTokenInfo = reissueApiService.reissueToken(refreshToken);
+        response.setHeader(AuthConstants.ACCESS_TOKEN_TYPE, reissueTokenInfo.getAccessToken());
+        response.addCookie(createCookie(AuthConstants.REFRESH_TOKEN_TYPE, reissueTokenInfo.getRefreshToken()));
+    }
+
+    private Cookie createCookie(String key, String value) {
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge((int) AuthConstants.REFRESH_TOKEN_TTL_MS);
+        cookie.setHttpOnly(true);
+        return cookie;
+    }
+}


### PR DESCRIPTION
- 리프레시 토큰 발급 추가
- 영속성 상태를 직접 관리하기 위해 Store 삭제
- 무조건 가게 - 비지니스정보가 있어야하기 때문에 nullable false로 수정
- 가게 추가할때 이미 가게가 있으면 에러를 뱉도록 코드 추가 (한명당 가게 하나만 있다고 가정함)